### PR TITLE
Transaction Commands: prevent commands from changing the list state

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BuyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BuyCommand.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GOODS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/commands/BuyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BuyCommand.java
@@ -71,7 +71,6 @@ public class BuyCommand extends Command {
         Company editedCompany = companyToEdit;
         editedCompany.addTransaction(transaction);
         model.setCompany(companyToEdit, editedCompany);
-        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedCompany, transaction.getQuantity(),
                 transaction.getGoods(), transaction.getPrice()));

--- a/src/main/java/seedu/address/logic/commands/SellCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SellCommand.java
@@ -72,7 +72,6 @@ public class SellCommand extends Command {
         Company editedCompany = companyToEdit;
         editedCompany.addTransaction(transaction);
         model.setCompany(companyToEdit, editedCompany);
-        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedCompany, transaction.getQuantity(),
                 transaction.getGoods(), transaction.getPrice()));

--- a/src/main/java/seedu/address/logic/commands/SellCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SellCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GOODS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
 
 import java.util.List;
 


### PR DESCRIPTION
Transaction commands will show full list instead of filtered list.

Allowing the list to stay in the filtered state is more user-friendly as users would not have to filter the list again to find the index of the company that they are adding transactions to.

Let's,
* remove the line that changes the filtered list to the full list state