### PR TITLE
Add Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -341,6 +341,7 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
+
 | Action         | Format, Examples                                                                                                                                       |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add**        | `add n/CLIENT a/ADDRESS p/PHONE e/EMAIL [t/TAG]...`<br> e.g., `add n/Alice a/Yishun Street 81 p/9876543 e/alice@gmail.com`                             |
@@ -360,6 +361,7 @@ _Details coming soon ..._
 | **View**       | `view INDEX` <br> e.g., `view 5`                                                                                                                       |
 
 ## Prefix Summary
+
 | Prefix     | Meaning                                        | Restrictions                                        | Example                       |
 |------------|------------------------------------------------|-----------------------------------------------------|-------------------------------|
 | **n/**     | Name of the client                             | Alphanumeric characters and spaces, required        | `n/Alice`                     |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -100,6 +100,10 @@ Format: `add n/NAME a/ADDRESS p/PHONE e/EMAIL [t/TAG]...`
 
 * Tags are optional.
 * Multiple tags can be tagged to the client.
+* No restrictions on the phone input field and email input field, but a warning will be given if it deviates from the standard convention.
+    * This facilitates more freedom to input phone numbers like `+606 89987755 (HOME)` and emails like `alice@company.com (WORK)`
+
+> :warning: **You cannot add a client with a name that already exists in JeeqTracker**: Names are considered duplicates even if they differ by case sensitivity or white spaces!
 
 Examples:
 * `add n/Alice a/West Coast Park p/9876542 e/alice@gmail.com`
@@ -356,15 +360,15 @@ _Details coming soon ..._
 | **View**       | `view INDEX` <br> e.g., `view 5`                                                                                                                       |
 
 ## Prefix Summary
-| Prefix     | Meaning                                        | Restrictions                                                | Example                       |
-|------------|------------------------------------------------|-------------------------------------------------------------|-------------------------------|
-| **n/**     | Name of the client                             | Alphanumeric characters and spaces, required                | `n/Alice`                     |
-| **a/**     | Address of the client                          | Required                                                    | `a/321 Clementi Road, #02-22` |
-| **p/**     | Phone number of the client                     | Should only contain numbers, required                       | `n/98765432`                  |
-| **e/**     | Email of the client                            | Should comply to the normal standards of an email, required | `e/alice@gmail.com`           |
-| **g/**     | Goods name of the transaction                  | Alphanumeric characters and spaces, required                | `g/Apples`                    |
-| **q/**     | Quantity of goods involved in the transaction  | Positive integer, required                                  | `q/10`                        |
-| **price/** | Price per quantity of goods in the transaction | Positive number, required                                   | `price/1.50`                  |
-| **m/**     | Mode of the command                            | Must be either `client`, `transaction`, or `remark`         | `m/client`                    |
-| **d/**     | Date of transaction                            | In the format `dd/mm/yyyy`                                  | `d/07/11/2022`                |
-| **t/**     | Tag applied on clients                         | Alphanumeric, single word                                   | `t/friends`                   |
+| Prefix     | Meaning                                        | Restrictions                                        | Example                       |
+|------------|------------------------------------------------|-----------------------------------------------------|-------------------------------|
+| **n/**     | Name of the client                             | Alphanumeric characters and spaces, required        | `n/Alice`                     |
+| **a/**     | Address of the client                          | Required                                            | `a/321 Clementi Road, #02-22` |
+| **p/**     | Phone number of the client                     | Required                                            | `n/98765432`                  |
+| **e/**     | Email of the client                            | Required                                            | `e/alice@gmail.com`           |
+| **g/**     | Goods name of the transaction                  | Alphanumeric characters and spaces, required        | `g/Apples`                    |
+| **q/**     | Quantity of goods involved in the transaction  | Positive integer, required                          | `q/10`                        |
+| **price/** | Price per quantity of goods in the transaction | Positive number, required                           | `price/1.50`                  |
+| **m/**     | Mode of the command                            | Must be either `client`, `transaction`, or `remark` | `m/client`                    |
+| **d/**     | Date of transaction                            | In the format `dd/mm/yyyy`                          | `d/07/11/2022`                |
+| **t/**     | Tag applied on clients                         | Alphanumeric, single word                           | `t/friends`                   |

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -67,6 +67,7 @@ public class AddCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddCommand // instanceof handles nulls
-                && toAdd.equals(((AddCommand) other).toAdd));
+                && toAdd.equals(((AddCommand) other).toAdd)
+                && warningMessage.equals(((AddCommand) other).warningMessage));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -37,13 +37,15 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_CLIENT = "This client already exists in the address book";
 
     private final Client toAdd;
+    private final String warningMessage;
 
     /**
      * Creates an AddCommand to add the specified {@code Client}
      */
-    public AddCommand(Client client) {
+    public AddCommand(Client client, String warningMessage) {
         requireNonNull(client);
-        toAdd = client;
+        this.toAdd = client;
+        this.warningMessage = warningMessage;
     }
 
     @Override
@@ -55,7 +57,10 @@ public class AddCommand extends Command {
         }
 
         model.addClient(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+
+        return warningMessage.isEmpty()
+                ? new CommandResult(String.format(MESSAGE_SUCCESS, toAdd))
+                : new CommandResult(String.format("WARNING!\n" + warningMessage + "\n" + MESSAGE_SUCCESS, toAdd));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -44,9 +44,18 @@ public class AddCommandParser implements Parser<AddCommand> {
         ClientEmail email = ParserUtil.parseClientEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        StringBuilder warningMessage = new StringBuilder();
+        if (phone.hasWarning()) {
+            warningMessage.append(ClientPhone.WARNING + "\n");
+        }
+
+        if (email.hasWarning()) {
+            warningMessage.append(ClientEmail.WARNING + "\n");
+        }
+
         Client client = new Client(name, address, phone, email, tagList);
 
-        return new AddCommand(client);
+        return new AddCommand(client, warningMessage.toString());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -59,15 +59,17 @@ public class ParserUtil {
      * Parses a {@code String phone} into a {@code ClientPhone}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code phone} is invalid.
      */
-    public static ClientPhone parseClientPhone(String phone) throws ParseException {
+    public static ClientPhone parseClientPhone(String phone) {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
+
+        ClientPhone newPhone = new ClientPhone(trimmedPhone);
         if (!ClientPhone.isValidPhone(trimmedPhone)) {
-            throw new ParseException(ClientPhone.MESSAGE_CONSTRAINTS);
+            newPhone.setWarning();
         }
-        return new ClientPhone(trimmedPhone);
+
+        return newPhone;
     }
 
     /**
@@ -104,15 +106,17 @@ public class ParserUtil {
      * Parses a {@code String email} into an {@code ClientEmail}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code email} is invalid.
      */
-    public static ClientEmail parseClientEmail(String email) throws ParseException {
+    public static ClientEmail parseClientEmail(String email) {
         requireNonNull(email);
         String trimmedEmail = email.trim();
+
+        ClientEmail newEmail = new ClientEmail(trimmedEmail);
         if (!ClientEmail.isValidEmail(trimmedEmail)) {
-            throw new ParseException(ClientEmail.MESSAGE_CONSTRAINTS);
+            newEmail.setWarning();
         }
-        return new ClientEmail(trimmedEmail);
+
+        return newEmail;
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 
@@ -127,7 +126,7 @@ public class Client implements ReadOnlyClient {
     }
 
     /**
-     * Returns true if both client have the same name.
+     * Returns true if both client have the same name (case-insensitive).
      * This defines a weaker notion of equality between two clients.
      */
     public boolean isSameClient(Client otherClient) {
@@ -135,8 +134,14 @@ public class Client implements ReadOnlyClient {
             return true;
         }
 
-        return otherClient != null
-                && otherClient.getName().equals(getName());
+        if (otherClient == null) {
+            return false;
+        }
+
+        String otherClientName = otherClient.getName().toString().toLowerCase().replace(" ", "");
+        String clientName = name.toString().toLowerCase().replace(" ", "");
+
+        return otherClientName.equals(clientName);
     }
 
     /**
@@ -182,17 +187,6 @@ public class Client implements ReadOnlyClient {
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
-        }
-
-        UniqueRemarkList remarks = getRemarks();
-        builder.append("; Remarks: ");
-        Iterator<Remark> itr = remarks.iterator();
-        String prefix = "";
-        while (itr.hasNext()) {
-            Remark remark = itr.next();
-            builder.append(prefix);
-            prefix = ", ";
-            builder.append(remark.getText());
         }
 
         TransactionLog transactions = getTransactions();

--- a/src/main/java/seedu/address/model/client/ClientEmail.java
+++ b/src/main/java/seedu/address/model/client/ClientEmail.java
@@ -1,7 +1,6 @@
 package seedu.address.model.client;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Client's email in the address book.
@@ -10,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class ClientEmail {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    public static final String WARNING = "Your email input does not follow the normal convention as follow: \n"
+            + "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
@@ -33,6 +33,8 @@ public class ClientEmail {
 
     public final String value;
 
+    private boolean hasWarning;
+
     /**
      * Constructs an {@code ClientEmail}.
      *
@@ -40,7 +42,6 @@ public class ClientEmail {
      */
     public ClientEmail(String email) {
         requireNonNull(email);
-        checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);
         value = email;
     }
 
@@ -49,6 +50,14 @@ public class ClientEmail {
      */
     public static boolean isValidEmail(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public void setWarning() {
+        this.hasWarning = true;
+    }
+
+    public boolean hasWarning() {
+        return this.hasWarning;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/client/ClientPhone.java
+++ b/src/main/java/seedu/address/model/client/ClientPhone.java
@@ -1,17 +1,21 @@
 package seedu.address.model.client;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Client's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
 public class ClientPhone {
-    public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+    public static final String WARNING =
+            "Your phone number input does not follow the normal convention of containing only numbers, "
+            + "and being at least 3 digits long";
+
     public static final String VALIDATION_REGEX = "\\d{3,}";
+
     public final String value;
+
+    private boolean hasWarning;
 
     /**
      * Constructs a {@code ClientPhone}.
@@ -20,7 +24,6 @@ public class ClientPhone {
      */
     public ClientPhone(String phone) {
         requireNonNull(phone);
-        checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
         value = phone;
     }
 
@@ -29,6 +32,14 @@ public class ClientPhone {
      */
     public static boolean isValidPhone(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public void setWarning() {
+        this.hasWarning = true;
+    }
+
+    public boolean hasWarning() {
+        return this.hasWarning;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -102,17 +102,11 @@ class JsonAdaptedClient {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     ClientPhone.class.getSimpleName()));
         }
-        if (!ClientPhone.isValidPhone(phone)) {
-            throw new IllegalValueException(ClientPhone.MESSAGE_CONSTRAINTS);
-        }
         final ClientPhone modelPhone = new ClientPhone(phone);
 
         if (email == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     ClientEmail.class.getSimpleName()));
-        }
-        if (!ClientEmail.isValidEmail(email)) {
-            throw new IllegalValueException(ClientEmail.MESSAGE_CONSTRAINTS);
         }
         final ClientEmail modelEmail = new ClientEmail(email);
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -26,20 +26,20 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
-    public void execute_newClient_success() {
+    public void execute_newClientWithoutWarning_success() {
         Client validClient = new ClientBuilder().build();
 
         Model expectedModel = new ModelManager(model.getJeeqTracker(), new UserPrefs());
         expectedModel.addClient(validClient);
 
-        assertCommandSuccess(new AddCommand(validClient), model,
+        assertCommandSuccess(new AddCommand(validClient, ""), model,
                 String.format(AddCommand.MESSAGE_SUCCESS, validClient), expectedModel);
     }
 
     @Test
     public void execute_duplicateClient_throwsCommandException() {
         Client clientInList = model.getJeeqTracker().getClientList().get(0);
-        assertCommandFailure(new AddCommand(clientInList), model, AddCommand.MESSAGE_DUPLICATE_CLIENT);
+        assertCommandFailure(new AddCommand(clientInList, ""), model, AddCommand.MESSAGE_DUPLICATE_CLIENT);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -27,7 +27,7 @@ public class AddCommandTest {
 
     @Test
     public void constructor_nullClient_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+        assertThrows(NullPointerException.class, () -> new AddCommand(null, ""));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class AddCommandTest {
         ModelStubAcceptingClientAdded modelStub = new ModelStubAcceptingClientAdded();
         Client validClient = new ClientBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validClient).execute(modelStub);
+        CommandResult commandResult = new AddCommand(validClient, "").execute(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validClient), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validClient), modelStub.clientsAdded);
@@ -44,7 +44,7 @@ public class AddCommandTest {
     @Test
     public void execute_duplicateClient_throwsCommandException() {
         Client validClient = new ClientBuilder().build();
-        AddCommand addCommand = new AddCommand(validClient);
+        AddCommand addCommand = new AddCommand(validClient, "");
         ModelStub modelStub = new ModelStubWithClient(validClient);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_CLIENT, () -> addCommand.execute(modelStub));
@@ -54,14 +54,14 @@ public class AddCommandTest {
     public void equals() {
         Client alice = new ClientBuilder().withName("Alice").build();
         Client bob = new ClientBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+        AddCommand addAliceCommand = new AddCommand(alice, "");
+        AddCommand addBobCommand = new AddCommand(bob, "");
 
         // same object -> returns true
         assertTrue(addAliceCommand.equals(addAliceCommand));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
+        AddCommand addAliceCommandCopy = new AddCommand(alice, "");
         assertTrue(addAliceCommand.equals(addAliceCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,6 +51,19 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_clientWithWarning_correctCommandResultAndAddsToModel() throws CommandException {
+        ModelStubAcceptingClientAdded modelStub = new ModelStubAcceptingClientAdded();
+        Client validClient = new ClientBuilder().build();
+
+        String warningMessage = "THIS IS A WARNING!";
+        CommandResult commandResult = new AddCommand(validClient, warningMessage).execute(modelStub);
+
+        assertEquals(String.format("WARNING!\n" + warningMessage + "\n" + AddCommand.MESSAGE_SUCCESS, validClient),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validClient), modelStub.clientsAdded);
+    }
+
+    @Test
     public void equals() {
         Client alice = new ClientBuilder().withName("Alice").build();
         Client bob = new ClientBuilder().withName("Bob").build();
@@ -72,6 +85,10 @@ public class AddCommandTest {
 
         // different client -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
+
+        // different warning message -> returns false
+        AddCommand addBobCommandCopy = new AddCommand(bob, "Different warning message!");
+        assertFalse(addBobCommandCopy.equals(addBobCommand));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -45,6 +45,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_GOODS_BUY_ORANGE = "orange";
     public static final String VALID_GOODS = " " + PREFIX_GOODS + VALID_GOODS_BUY_ORANGE;
+    public static final String INVALID_PHONE = "+65 8877 6644";
+    public static final String INVALID_EMAIL = "bob@gmail.com (HOME)";
 
     public static final String VALID_GOODS_SELL_PAPAYA = "papaya";
     public static final String VALID_PRICE_BUY_ORANGE = "1";
@@ -73,6 +75,8 @@ public class CommandTestUtil {
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + INVALID_PHONE;
+    public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + INVALID_EMAIL;
 
     public static final String INVALID_QUANTITY = " " + PREFIX_QUANTITY + "J100"; // Characters not allowed in quantity
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -46,27 +46,27 @@ public class AddCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB
                 + ADDRESS_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedClient));
+                + TAG_DESC_FRIEND, new AddCommand(expectedClient, ""));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB
                 + ADDRESS_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedClient));
+                + TAG_DESC_FRIEND, new AddCommand(expectedClient, ""));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB
                 + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB, new AddCommand(expectedClient));
+                + PHONE_DESC_BOB, new AddCommand(expectedClient, ""));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB
                 + ADDRESS_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedClient));
+                + TAG_DESC_FRIEND, new AddCommand(expectedClient, ""));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + ADDRESS_DESC_AMY
                 + ADDRESS_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedClient));
+                + TAG_DESC_FRIEND, new AddCommand(expectedClient, ""));
 
         // multiple tags - all accepted
         Client expectedClientMultipleTags = new ClientBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
@@ -74,7 +74,7 @@ public class AddCommandParserTest {
 
         assertParseSuccess(parser, NAME_DESC_BOB + ADDRESS_DESC_BOB
                 + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedClientMultipleTags));
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedClientMultipleTags, ""));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class AddCommandParserTest {
         Client expectedClient = new ClientBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + ADDRESS_DESC_AMY
                 + PHONE_DESC_AMY + EMAIL_DESC_AMY,
-                new AddCommand(expectedClient));
+                new AddCommand(expectedClient, ""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/JeeqTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/JeeqTrackerParserTest.java
@@ -58,7 +58,7 @@ public class JeeqTrackerParserTest {
     public void parseCommand_add() throws Exception {
         Client client = new ClientBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(ClientUtil.getAddCommand(client));
-        assertEquals(new AddCommand(client), command);
+        assertEquals(new AddCommand(client, ""), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -39,7 +40,6 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
-    private static final String VALID_TEXT = "Good buyer";
     private static final String WHITESPACE = " \t\r\n";
 
     @Test
@@ -104,21 +104,21 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseClientPhone_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseClientPhone(INVALID_PHONE));
+    public void parseClientPhone_validValue_returnsPhoneWithoutWarning() {
+        ClientPhone phone = ParserUtil.parseClientPhone(VALID_PHONE);
+        assertFalse(phone.hasWarning());
+    }
+
+    @Test
+    public void parseClientPhone_invalidValue_returnsPhoneWithWarning() {
+        ClientPhone phone = ParserUtil.parseClientPhone(INVALID_PHONE);
+        assertTrue(phone.hasWarning());
     }
 
     @Test
     public void parseClientPhone_validValueWithoutWhitespace_returnsPhone() throws Exception {
         ClientPhone expectedPhone = new ClientPhone(VALID_PHONE);
         assertEquals(expectedPhone, ParserUtil.parseClientPhone(VALID_PHONE));
-    }
-
-    @Test
-    public void parseClientPhone_withWhitespace_returnsTrimmedPhone() throws Exception {
-        String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
-        ClientPhone expectedPhone = new ClientPhone(VALID_PHONE);
-        assertEquals(expectedPhone, ParserUtil.parseClientPhone(phoneWithWhitespace));
     }
 
     @Test
@@ -157,8 +157,15 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseClientEmail_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseClientEmail(INVALID_EMAIL));
+    public void parseClientEmail_invalidValue_returnsEmailWithWarning() {
+        ClientEmail email = ParserUtil.parseClientEmail(INVALID_EMAIL);
+        assertTrue(email.hasWarning());
+    }
+
+    @Test
+    public void parseClientEmail_validValue_returnsEmailWithoutWarning() {
+        ClientEmail email = ParserUtil.parseClientEmail(VALID_EMAIL);
+        assertFalse(email.hasWarning());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/client/ClientEmailTest.java
+++ b/src/test/java/seedu/address/model/client/ClientEmailTest.java
@@ -15,12 +15,6 @@ public class ClientEmailTest {
     }
 
     @Test
-    public void constructor_invalidEmail_throwsIllegalArgumentException() {
-        String invalidEmail = "";
-        assertThrows(IllegalArgumentException.class, () -> new ClientEmail(invalidEmail));
-    }
-
-    @Test
     public void isValidEmail() {
         // null email
         assertThrows(NullPointerException.class, () -> ClientEmail.isValidEmail(null));

--- a/src/test/java/seedu/address/model/client/ClientPhoneTest.java
+++ b/src/test/java/seedu/address/model/client/ClientPhoneTest.java
@@ -15,12 +15,6 @@ class ClientPhoneTest {
     }
 
     @Test
-    public void constructor_invalidPhone_throwsIllegalArgumentException() {
-        String invalidPhone = "";
-        assertThrows(IllegalArgumentException.class, () -> new ClientPhone(invalidPhone));
-    }
-
-    @Test
     public void isValidPhone() {
         // null phone number
         assertThrows(NullPointerException.class, () -> ClientPhone.isValidPhone(null));
@@ -38,6 +32,7 @@ class ClientPhoneTest {
         assertTrue(ClientPhone.isValidPhone("93121534"));
         assertTrue(ClientPhone.isValidPhone("124293842033123")); // long phone numbers
     }
+
     @Test
     public void toString_phone_returnsValueInPhone() {
         String value = "93121534";

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalClients.ALICE;
+import static seedu.address.testutil.TypicalClients.AMY;
 import static seedu.address.testutil.TypicalClients.BOB;
 import static seedu.address.testutil.TypicalRemark.BAD_BUYER;
 import static seedu.address.testutil.TypicalRemark.BAD_SELLER;
@@ -85,14 +87,18 @@ public class ClientTest {
         editedAlice = new ClientBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameClient(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Client editedBob = new ClientBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameClient(editedBob));
+        assertTrue(BOB.isSameClient(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name differs in spacing between words, all other attributes same -> returns true
+        Client editedAmy = new ClientBuilder(AMY).withName(VALID_NAME_AMY.replace(" ", "   ")).build();
+        assertTrue(AMY.isSameClient(editedAmy));
+
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new ClientBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameClient(editedBob));
+        assertTrue(BOB.isSameClient(editedBob));
     }
 
     @Test
@@ -182,6 +188,6 @@ public class ClientTest {
 
         assertEquals(client.toString(), "Benson Meier; Address: 311, Clementi Ave 2, "
                 + "#02-25; Phone: 12112121; Email: ben@gmail.com; "
-                + "Tags: [owesMoney][friends]; Remarks: Bad Buyer; Total transactions: -$423");
+                + "Tags: [owesMoney][friends]; Total transactions: -$423");
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -80,28 +80,10 @@ public class JsonAdaptedClientTest {
     }
 
     @Test
-    public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_ADDRESS,
-                        INVALID_PHONE, VALID_EMAIL, VALID_TAGS, VALID_REMARKS, VALID_TRANSACTIONS);
-        String expectedMessage = ClientPhone.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
-    }
-
-    @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_ADDRESS,
                 null, VALID_EMAIL, VALID_TAGS, VALID_REMARKS, VALID_TRANSACTIONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ClientPhone.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedClient client =
-                new JsonAdaptedClient(VALID_NAME, VALID_ADDRESS,
-                        VALID_PHONE, INVALID_EMAIL, VALID_TAGS, VALID_REMARKS, VALID_TRANSACTIONS);
-        String expectedMessage = ClientEmail.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 


### PR DESCRIPTION
# Duplicate name
Add case insensitivity when detecting for name duplicates.
 `Alice Lee` is the same as `aLicE LeE` and `Alice                 Lee`, so there will be an error when adding.

# Phone and Email less restrictions
Creating a client with phone `+65 9488 3993`, `9488 3993 (HOME)`, is allowed now to increase flexibility, but a warning message will be given.

Creating a client with email `elgin@example.com (HOME)`, `what?`, is allowed now to increase flexibility, but a warning message will be given telling the user that they have violated the normal convention